### PR TITLE
fix: event names should not end on Event

### DIFF
--- a/src/videoplayer-common.ts
+++ b/src/videoplayer-common.ts
@@ -38,7 +38,7 @@ export class VideoCommon extends View {
   /**
    * String value for hooking into the errorEvent. This event fires when an error/exception throws in the Video source.
    */
-  public static errorEvent = 'errorEvent';
+  public static errorEvent = 'error';
 
   /**
    * String value for hooking into the finishedEvent. This event fires when the video is ready.
@@ -62,27 +62,27 @@ export class VideoCommon extends View {
   /**
    * String value for hooking into the finishedEvent. This event fires when the video is complete.
    */
-  public static finishedEvent = 'finishedEvent';
+  public static finishedEvent = 'finished';
 
   /**
    * String value for hooking into the mutedEvent. This event fires when video is muted.
    */
-  public static mutedEvent = 'mutedEvent';
+  public static mutedEvent = 'muted';
 
   /**
    * String value for hooking into the unmutedEvent. This event fires when video is unmutedEvent.
    */
-  public static unmutedEvent = 'unmutedEvent';
+  public static unmutedEvent = 'unmuted';
 
   /**
    * String value for hooking into the pausedEvent. This event fires when video is paused.
    */
-  public static pausedEvent = 'pausedEvent';
+  public static pausedEvent = 'paused';
 
   /**
    * String value for hooking into the volumeSetEvent. This event fires when the volume is set.
    */
-  public static volumeSetEvent = 'volumeSetEvent';
+  public static volumeSetEvent = 'volumeSet';
 
   /**
    * The android nativeView for the VideoPlayer. android.view.TextureView.


### PR DESCRIPTION
Fixes #152.

I've separated this fix from my other PR because of possible breaking changes. I can merge them if you want :)

**Possible (?) Breaking Change:**


Event names that ended in `Event` are now changed, as they do not work correctly with NS (https://github.com/NativeScript/NativeScript/blob/e0c49333377a5f85de911a6e952574fb24df71da/tns-core-modules/ui/core/view/view-common.ts#L433 and https://github.com/NativeScript/NativeScript/blob/dfcbe6c319485b87c0d619b075f661f769316c8d/tns-core-modules/ui/core/bindable/bindable.ts#L89).

Event names must be exactly `EvtNameEvent = "EvtName";` to work with the Core's binding. This is possible not a breaking change because it never worked (and everyone else is probably using `Video.finishedEvent`), so this is only a breaking change for people using `video.on('finishedEvent', ...)`
