### PR TITLE
Set audio session category and options

### DIFF
--- a/src/videoplayer.ios.ts
+++ b/src/videoplayer.ios.ts
@@ -118,7 +118,15 @@ export class Video extends VideoCommon {
 
   public play() {
     CLog(CLogTypes.info, 'Video.play');
-    if (this._videoFinished) {
+
+	let audioSession = AVAudioSession.sharedInstance();
+	audioSession.setCategoryWithOptionsError(
+		AVAudioSessionCategoryAmbient,
+		AVAudioSessionCategoryOptions.DuckOthers
+	);
+	audioSession.setActiveError(true);
+
+	if (this._videoFinished) {
       this._videoFinished = false;
       this.seekToTime(5);
     }
@@ -138,6 +146,9 @@ export class Video extends VideoCommon {
     if (this._playbackTimeObserverActive) {
       this._removePlaybackTimeObserver();
     }
+
+	let audioSession = AVAudioSession.sharedInstance();
+	setTimeout(() => audioSession.setActiveError(false), 100);
   }
 
   public mute(mute: boolean) {


### PR DESCRIPTION
Allows audio to come through the main speaker at full volume

I get no audio (or audio comes from top speaker only, at a volume consistent with a phone call) when playing a video without this change. If there's a better way to solve the problem, or if I'm overlooking something, let me know.