### PR TITLE
Fixed incorrect module in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ video.loop = false;
 ```TS
 // somewhere at top of your component or bootstrap file
 import { registerElement } from '@nativescript/angular';
-import { Video } from '@nstudio/nativescript-exoplayer';
+import { Video } from 'nativescript-videoplayer';
 registerElement('VideoPlayer', () => Video);
 // documentation: https://docs.nativescript.org/angular/plugins/angular-third-party.html#simple-elements
 ```


### PR DESCRIPTION
For Angular, example code is incorrectly referencing module `@nstudio/nativescript-exoplayer`, instead of `nativescript-videoplayer`.
Once replaced with a correct name, Angular code example can be copy-pasted into projects, works with no issues.